### PR TITLE
replace offline icon with a gray one to aide the eyes in distinguishing it from the "busy" status

### DIFF
--- a/img/status/offline.svg
+++ b/img/status/offline.svg
@@ -4,7 +4,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 10 10" enable-background="new 0 0 10 10" xml:space="preserve">
 <g>
-	<path fill="#C94F50" d="M5,1.5c1.9,0,3.5,1.6,3.5,3.5S6.9,8.5,5,8.5C3.1,8.5,1.5,6.9,1.5,5S3.1,1.5,5,1.5 M5,0C2.2,0,0,2.2,0,5
+	<path fill="#777777" d="M5,1.5c1.9,0,3.5,1.6,3.5,3.5S6.9,8.5,5,8.5C3.1,8.5,1.5,6.9,1.5,5S3.1,1.5,5,1.5 M5,0C2.2,0,0,2.2,0,5
 		s2.2,5,5,5c2.8,0,5-2.2,5-5S7.8,0,5,0z"/>
 </g>
 </svg>


### PR DESCRIPTION
with this patch, fusion light theme would look like this:
![image](https://user-images.githubusercontent.com/2938071/210595106-5ba99739-6a13-43dd-a5a7-f604b3775a77.png)
